### PR TITLE
Add query option in function delete.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -526,6 +526,8 @@ Index.prototype = {
       @param {Number} [options.version] Document version to delete. If
           the specified document's version differs from this, an error will be
           returned and the document will not be deleted.
+      @param {object} [options.query] To perform removal using a query. Warning:
+          id and all other options except ignoreMissing will be ignored.
     @param {Function} [callback] Callback function.
       @param {Error|null} callback.err Error, or `null` on success.
       @param {Object} callback.res ElasticSearch response.
@@ -548,31 +550,46 @@ Index.prototype = {
             delete params.ignoreMissing;
         }
 
-        util.each(params, function (value, name) {
-            if (value === true || value === false) {
-                value = value ? '1' : '0';
-            }
+        if(params.query) {
+          url = '/' + encode(this.name) + '/' + encode(type) + '/_query';
+          
+          this.client._request(url, {method: 'DELETE', json: params.query}, function (err, res) {
+              if (err) {
+                  if (ignoreMissing && res && res.found === false) {
+                      return callback(null, res), undefined;
+                  } else {
+                      return callback(err, res), undefined;
+                  }
+              }
+              callback(null, res);
+          });
+        } else {         
+          util.each(params, function (value, name) {
+              if (value === true || value === false) {
+                  value = value ? '1' : '0';
+              }
+  
+              query.push(encode(name) + '=' + encode(value));
+          });
+          
+          url = '/' + encode(this.name) + '/' + encode(type) + '/' + encode(id);
 
-            query.push(encode(name) + '=' + encode(value));
-        });
-
-        url = '/' + encode(this.name) + '/' + encode(type) + '/' + encode(id);
-
-        if (query.length) {
-            url += '?' + query.join('&');
+          if (query.length) {
+              url += '?' + query.join('&');
+          }
+          
+          this.client._request(url, {method: 'DELETE'}, function (err, res) {
+              if (err) {
+                  if (ignoreMissing && res && res.found === false) {
+                      return callback(null, res), undefined;
+                  } else {
+                      return callback(err, res), undefined;
+                  }
+              }
+  
+              callback(null, res);
+          });
         }
-
-        this.client._request(url, {method: 'DELETE'}, function (err, res) {
-            if (err) {
-                if (ignoreMissing && res && res.found === false) {
-                    return callback(null, res), undefined;
-                } else {
-                    return callback(err, res), undefined;
-                }
-            }
-
-            callback(null, res);
-        });
     },
 
     /**

--- a/tests/offline-tests.js
+++ b/tests/offline-tests.js
@@ -227,6 +227,20 @@ vows.describe('Elastical').addBatch({
                         version    : '18'
                     }, query);
                 }
+            },
+      
+            'with query option': {
+                topic: function (client) {
+                    client._testHook = this.callback;
+                    client.delete('posts', 'post', '', {
+                        query: {"term" : { "user" : "kimchy" }}
+                    });
+                },
+
+                'URL query string should contain the options': function (err, options) {
+                    var query = parseUrl(options.uri, true).query;
+                    assert.deepEqual('http://example.com:42/posts/post/_query', options.uri);
+                }
             }
         },
 

--- a/tests/online-tests.js
+++ b/tests/online-tests.js
@@ -815,6 +815,88 @@ vows.describe('Elastical')
     }
 })
 .addBatch({
+    'Client (Test client.delete with query option)': {
+        topic: new elastical.Client(),
+
+        'index called with `options.id`': {
+            topic: function (client) {
+                client.index('elastical-test-delete', 'tweet', {
+                    "user" : "kimchy",
+                    "post_date" : "2009-11-15T14:12:12",
+                    "message" : "trying out Elastic Search"
+                  }, 
+                  {id: 123456789}, this.callback);
+            },
+
+            'should add or update the document with that id': function (err, res) {
+                assert.isNull(err);
+                assert.isObject(res);
+                assert.isTrue(res.ok);
+                assert.equal(res._index, 'elastical-test-delete');
+                assert.equal(res._type, 'tweet');
+                assert.equal(res._id, 123456789);
+            }
+        },
+        
+        '`get()`': {
+            'when trying to find the indexed document': {
+                topic: function (client) {
+                    client.get('elastical-test-delete', '123456789', this.callback);
+                },
+
+                'should get the document': function (err, doc, res) {
+                    assert.isNull(err);
+                    assert.isObject(doc);
+                    assert.isObject(res);
+                    assert.isFalse(res.exists);
+                }
+            }
+        },
+        
+        '`delete()`': {
+            'when called with query options': {
+                topic: function (client) {
+                    client.delete('elastical-test-delete', 'tweet', '', {
+                        query: {"term" : { "user" : "kimchy" }}
+                    }, this.callback);
+                },
+
+                'should delete the given document': function (err, res) {
+                    assert.isNull(err);
+                    assert.isObject(res);
+                }
+            }
+        },
+        
+        '`refresh()`': {
+            'with no index': {
+                topic: function (client) {
+                    client.refresh(this.callback);
+                },
+
+                'should succeed': function (err, res) {
+                    assert.isNull(err);
+                    assert.isObject(res);
+                    assert.isTrue(res.ok);
+                    assert.isObject(res._shards);
+                }
+            }
+        },
+        
+        '`get()`': {
+            'when trying to find the deleted document': {
+                topic: function (client) {
+                    client.get('elastical-test-delete', '123456789', this.callback);
+                },
+
+                'should NOT get the document': function (err, doc, res) {
+                  assert.equal(err, 'Error: HTTP 404');
+                }
+            }
+        }
+    }
+})
+.addBatch({
     'Client (part deux)': {
         topic: new elastical.Client(),
 


### PR DESCRIPTION
Currently, the only way of deleting using a query is to "hack" function delete with something like:

``` Javascript
client.delete('twitter', 'tweet', '', {q: 'user:Shay'} );
```

The aim of the modification is to be able to do things like:

```
$ curl -XDELETE 'http://localhost:9200/twitter/tweet/_query' -d '{
    "term" : { "user" : "kimchy" }
}
'
```

So, by passing an object to the query option, we can now perform similare request.
Example: 

```
client.delete('twitter', 'tweet', '', {query: {           
    "term" : { "user" : "kimchy" }
} });
```
