### PR TITLE
dot not transform null into {}

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -73,7 +73,10 @@ function mix() {
             key   = keys[i];
             value = source[key];
 
-            if (typeof value === 'object' && !Array.isArray(value)) {
+            if(value == null){
+                // if value is null or undefined keep the value intact.
+                target[key] = value;
+            }else if (typeof value === 'object' && !Array.isArray(value)) {
                 typeof target[key] === 'object' || (target[key] = {});
                 mix(target[key], value);
             } else {

--- a/tests/offline-tests.js
+++ b/tests/offline-tests.js
@@ -228,7 +228,7 @@ vows.describe('Elastical').addBatch({
                     }, query);
                 }
             },
-      
+
             'with query option': {
                 topic: function (client) {
                     client._testHook = this.callback;
@@ -340,7 +340,9 @@ vows.describe('Elastical').addBatch({
                     client._testHook = this.callback;
                     client.index('blog', 'post', {
                         title  : 'Hello',
-                        content: 'Moo.'
+                        content: 'Moo.',
+                        option: null,
+                        option2: undefined
                     });
                 },
 
@@ -353,9 +355,11 @@ vows.describe('Elastical').addBatch({
                 },
 
                 'request body should be set': function (err, options) {
+                    delete options.json.option2;
                     assert.deepEqual({
                         title  : 'Hello',
-                        content: 'Moo.'
+                        content: 'Moo.',
+                        option: null
                     }, options.json);
                 }
             },


### PR DESCRIPTION
Curently elastical transform null  value into the empty object.

```
{
  option: null
}
```

become

```
{
  option: {}
}
```

The PR fix this.

ElasticSearch works great with the null value, there is no need to change this behaviour.
