### PR TITLE
Omit Port from baseUrl

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -51,7 +51,12 @@ function Client(host, options) {
     this.host    = host || '127.0.0.1';
     this.options = options || {};
 
-    this.options.port || (this.options.port = 9200);
+    if(typeof this.options.port === 'undefined') {
+      this.options.port = 9200;
+    }
+    else if(this.options.port === null) {
+      this.options.port = null;
+    }
     this.options.protocol || (this.options.protocol = 'http');
     this.options.timeout || (this.options.timeout = 60000);
 
@@ -83,9 +88,15 @@ Client.prototype = {
     @type {String}
     **/
     get baseUrl() {
-        return this.options.protocol + '://' +
+        var baseUrl = this.options.protocol + '://' +
             (this.options.auth ? this.options.auth + '@' : '') +
-            this.host + ':' + this.options.port;
+            this.host;
+
+        if(this.options.port !== null) {
+          baseUrl = baseUrl + ':' + this.options.port;
+        }
+        
+        return baseUrl;
     },
 
     /**
@@ -524,7 +535,7 @@ Client.prototype = {
             callback = options;
             options  = {};
         }
-				var useScrollingEndpoint = (options.scroll_id != null);
+        var useScrollingEndpoint = (options.scroll_id != null);
         // Create a copy of options so we can modify it.
         options = util.merge(options || {});
 
@@ -577,9 +588,9 @@ Client.prototype = {
 
         url += '/_search';
 
-				if(useScrollingEndpoint){
-					url += '/scroll';
-				}
+        if(useScrollingEndpoint){
+          url += '/scroll';
+        }
 
         if (query.length) {
             url += '?' + query.join('&');


### PR DESCRIPTION
If Port is set to null, it will be omitted from the baseUrl. I'm using Searchbox.io, and the URL they give you to make requests to does not include a port.
