### PR TITLE
Added support for base URL

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -36,6 +36,9 @@ established as needed and are not persistent.
     @param {Number} [options.port=9200] Port to connect to.
     @param {String} [options.protocol='http'] Protocol to use. May be "http" or
         "https".
+    @param {String} [options.basePath=''] Optional base path to prepend to all 
+        query paths. This can be useful if acessing a cluster on a host that 
+        uses paths to namespace customer indexes.
     @param {Number} [options.timeout=60000] Number of milliseconds to wait
         before aborting a request. Be sure to increase this if you do large bulk
         operations.
@@ -59,6 +62,7 @@ function Client(host, options) {
     }
     this.options.protocol || (this.options.protocol = 'http');
     this.options.timeout || (this.options.timeout = 60000);
+    this.options.basePath || (this.options.basePath = null);
 
     this._indexCache = {};
 }
@@ -94,6 +98,10 @@ Client.prototype = {
 
         if(this.options.port !== null) {
           baseUrl = baseUrl + ':' + this.options.port;
+        }
+
+        if(this.options.basePath !== null) {
+          baseUrl = baseUrl + this.options.basePath;
         }
         
         return baseUrl;


### PR DESCRIPTION
I've been looking at a few different ES hosts, and noticed that some of them (e.g. qbox.io) add a namespace path before the index portion of the path, which makes them incompatible with Elastical as it stands.

e.g.

```
curl -X PUT http://api.qbox.io/namespaceName/indexName -d '{
    "number_of_shards" : 4,
    "number_of_replicas" : 1
}'
```

This change adds a simple option to allow Elastical to be configured to support base paths
