### PR TITLE
Fix river api

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -908,7 +908,7 @@ Client.prototype = {
       @param {Object} callback.res ElasticSearch response data.
     @static
     **/
-    putRiver: wrapIndexMethod('putRiver'),
+    putRiver: wrapStaticIndexMethod('putRiver'),
 
     /**
     Gets river config from the cluster.
@@ -922,7 +922,7 @@ Client.prototype = {
       @param {Object} callback.res ElasticSearch response data.
     @static
     **/
-    getRiver: wrapIndexMethod('getRiver'),
+    getRiver: wrapStaticIndexMethod('getRiver'),
 
     /**
     Deletes a river config from the cluster.
@@ -937,7 +937,7 @@ Client.prototype = {
       @param {Object} callback.res ElasticSearch response data.
     @static
     **/
-    deleteRiver: wrapIndexMethod('deleteRiver'),
+    deleteRiver: wrapStaticIndexMethod('deleteRiver'),
 
     // -- Protected Methods ----------------------------------------------------
 

--- a/tests/offline-tests.js
+++ b/tests/offline-tests.js
@@ -65,7 +65,7 @@ vows.describe('Elastical').addBatch({
                     },
 
                     'URL should not have a query string': function (err, options) {
-                        assert.isUndefined(parseUrl(options.uri).search);
+                        assert.isNull(parseUrl(options.uri).search);
                     },
 
                     'body should be formatted correctly': function (err, options) {
@@ -197,7 +197,7 @@ vows.describe('Elastical').addBatch({
                 },
 
                 'URL should not have a query string': function (err, options) {
-                    assert.isUndefined(parseUrl(options.uri).search);
+                    assert.isNull(parseUrl(options.uri).search);
                 }
             },
 

--- a/tests/offline-tests.js
+++ b/tests/offline-tests.js
@@ -635,7 +635,7 @@ vows.describe('Elastical').addBatch({
             'no filters': {
                 topic: function (client) {
                     client._testHook = this.callback;
-                    client.putRiver('_river','my_river_name', { type : 'couchdb', couchdb : { host : 'localhost' }, index : {} } );
+                    client.putRiver('my_river_name', { type : 'couchdb', couchdb : { host : 'localhost' }, index : {} } );
                 },
 
                 'method should be PUT': function (err, options) {
@@ -656,7 +656,7 @@ vows.describe('Elastical').addBatch({
             'basic': {
                 topic: function (client) {
                     client._testHook = this.callback;
-                    client.getRiver('_river','my_river_name' );
+                    client.getRiver('my_river_name' );
                 },
 
                 'method should be GET': function (err, options) {
@@ -673,7 +673,7 @@ vows.describe('Elastical').addBatch({
             'basic': {
                 topic: function (client) {
                     client._testHook = this.callback;
-                    client.deleteRiver('_river','my_river_name' );
+                    client.deleteRiver('my_river_name' );
                 },
 
                 'method should be DELETE': function (err, options) {

--- a/tests/online-tests.js
+++ b/tests/online-tests.js
@@ -1029,7 +1029,7 @@ vows.describe('Elastical')
 
         '`putRiver()`': {
             topic: function (client) {
-                client.putRiver( 'elastical-test-river', 'elastical-test-river-put', { type:'dummy' }, this.callback );
+                client.putRiver( 'elastical-test-river-put', { type:'dummy' }, this.callback );
             },
 
             'should return ok': function (err, results, res) {
@@ -1041,7 +1041,7 @@ vows.describe('Elastical')
 
         '`getRiver()`': {
             topic: function (client) {
-                client.getRiver( 'elastical-test-river', 'elastical-test-river-get', this.callback );
+                client.getRiver( 'elastical-test-river-get', this.callback );
             },
 
             'should return ok': function (err, results, res) {
@@ -1053,7 +1053,7 @@ vows.describe('Elastical')
 
         '`deleteRiver()`': {
             topic: function (client) {
-                client.deleteRiver( 'elastical-test-river', 'elastical-test-river-delete', this.callback );
+                client.deleteRiver( 'elastical-test-river-delete', this.callback );
             },
 
             'should return ok': function (err, results, res) {


### PR DESCRIPTION
This fix should close #18.
Client `putRiver`, `getRiver` and `deleteRiver` methods are created using the `wrapIndexMethod` helper: this results in Index methods being called without the name parameter. Using `wrapStaticIndexMethod` solved the problem.
