### PR TITLE
Fix delete by query : could now be called with no type / multiple types

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -755,44 +755,48 @@ Index.prototype = {
         }
 
         if(params.query) {
-          url = '/' + encode(this.name) + '/' + encode(type) + '/_query';
-
-          this.client._request(url, {method: 'DELETE', json: params.query}, function (err, res) {
-              if (err) {
-                  if (ignoreMissing && res && res.found === false) {
-                      return callback(null, res), undefined;
-                  } else {
-                      return callback(err, res), undefined;
-                  }
-              }
-              callback(null, res);
-          });
+            url = '/' + encode(this.name);
+            if (type) {
+                url += '/' + encode(Array.isArray(type) ? type.join(',') : type);
+            }
+            url += '/_query';
+            
+            this.client._request(url, {method: 'DELETE', json: params.query}, function (err, res) {
+                if (err) {
+                    if (ignoreMissing && res && res.found === false) {
+                        return callback(null, res), undefined;
+                    } else {
+                        return callback(err, res), undefined;
+                    }
+                }
+                callback(null, res);
+            });
         } else {
-          util.each(params, function (value, name) {
-              if (value === true || value === false) {
-                  value = value ? '1' : '0';
-              }
-
-              query.push(encode(name) + '=' + encode(value));
-          });
-
-          url = '/' + encode(this.name) + '/' + encode(type) + '/' + encode(id);
-
-          if (query.length) {
-              url += '?' + query.join('&');
-          }
-
-          this.client._request(url, {method: 'DELETE'}, function (err, res) {
-              if (err) {
-                  if (ignoreMissing && res && res.found === false) {
-                      return callback(null, res), undefined;
-                  } else {
-                      return callback(err, res), undefined;
-                  }
-              }
-
-              callback(null, res);
-          });
+            util.each(params, function (value, name) {
+                if (value === true || value === false) {
+                    value = value ? '1' : '0';
+                }
+  
+                query.push(encode(name) + '=' + encode(value));
+            });
+  
+            url = '/' + encode(this.name) + '/' + encode(type) + '/' + encode(id);
+  
+            if (query.length) {
+                url += '?' + query.join('&');
+            }
+  
+            this.client._request(url, {method: 'DELETE'}, function (err, res) {
+                if (err) {
+                    if (ignoreMissing && res && res.found === false) {
+                        return callback(null, res), undefined;
+                    } else {
+                        return callback(err, res), undefined;
+                    }
+                }
+  
+                callback(null, res);
+            });
         }
     },
 

--- a/tests/offline-tests.js
+++ b/tests/offline-tests.js
@@ -65,7 +65,7 @@ vows.describe('Elastical').addBatch({
                     },
 
                     'URL should not have a query string': function (err, options) {
-                        assert.isNull(parseUrl(options.uri).search);
+                        assert.isNull(parseUrl(options.uri).search || null);
                     },
 
                     'body should be formatted correctly': function (err, options) {
@@ -197,7 +197,7 @@ vows.describe('Elastical').addBatch({
                 },
 
                 'URL should not have a query string': function (err, options) {
-                    assert.isNull(parseUrl(options.uri).search);
+                    assert.isNull(parseUrl(options.uri).search || null);
                 }
             },
 
@@ -240,6 +240,34 @@ vows.describe('Elastical').addBatch({
                 'URL query string should contain the options': function (err, options) {
                     var query = parseUrl(options.uri, true).query;
                     assert.deepEqual('http://example.com:42/posts/post/_query', options.uri);
+                }
+            },
+
+            'with query option and without type': {
+                topic: function (client) {
+                    client._testHook = this.callback;
+                    client.delete('posts', '', '', {
+                        query: {"term" : { "user" : "kimchy" }}
+                    });
+                },
+
+                'URL query string should contain the options': function (err, options) {
+                    var query = parseUrl(options.uri, true).query;
+                    assert.deepEqual('http://example.com:42/posts/_query', options.uri);
+                }
+            },
+
+            'with query option and multiple types': {
+                topic: function (client) {
+                    client._testHook = this.callback;
+                    client.delete('posts', ['post','tweet'], '', {
+                        query: {"term" : { "user" : "kimchy" }}
+                    });
+                },
+
+                'URL query string should contain the options': function (err, options) {
+                    var query = parseUrl(options.uri, true).query;
+                    assert.deepEqual('http://example.com:42/posts/post%2Ctweet/_query', options.uri);
                 }
             }
         },


### PR DESCRIPTION
As specified in the delete-by-query API (http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-delete-by-query.html), I updated the 'delete' function to allow queries without type or with multiple types.
