### PR TITLE
add support for mlt queries (+offline tests)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -317,6 +317,35 @@ Client.prototype = {
     get: wrapIndexMethod('get'),
 
     /**
+    Perform an mlt query on a document index based on its type and id.
+
+    [ElasticSearch docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-more-like-this.html)
+
+    @example
+
+      var client = new require('elastical').Client();
+
+      client.mlt('twitter', 'tweet', 1, function (err, hits) {
+          if (err) { throw err; }
+          console.log(hits);
+      };
+
+    @method get
+    @param {String} name Index name.
+    @param {String} type Document type.
+    @param {String} id Document id.
+    @param {Object} [options] Options.
+      @param {String|String[]} [options.fields] Document field name or array of
+          field names to retrieve. By default, all fields are retrieved.
+    @param {Function} callback Callback function.
+      @param {Error|null} callback.err Error, or `null` on success.
+      @param {Object} callback.results Search results.
+      @param {Object} callback.res Full ElasticSearch response data.
+    @see Index.get
+    **/
+    mlt: wrapIndexMethod('mlt'),
+
+    /**
     Gets an Index instance for interacting with the specified ElasticSearch
     index.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -952,9 +952,19 @@ Index.prototype = {
 
         params = util.merge(options);
 
-        if (params.fields) {
-            params.fields = Array.isArray(params.fields) ?
-                params.fields.join(',') : params.fields;
+        if (params.mlt_fields) {
+            params.mlt_fields = Array.isArray(params.mlt_fields) ?
+                params.mlt_fields.join(',') : params.mlt_fields;
+        }
+
+        if (params.search_indices) {
+            params.search_indices = Array.isArray(params.search_indices) ?
+                params.search_indices.join(',') : params.search_indices;
+        }
+
+        if (params.search_types) {
+            params.search_types = Array.isArray(params.search_types) ?
+                params.search_types.join(',') : params.search_types;
         }
 
         util.each(params, function (value, name) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -926,6 +926,61 @@ Index.prototype = {
     },
 
     /**
+    Perform an mlt query on a document index based on its type and id.
+
+    [ElasticSearch docs](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-more-like-this.html)
+
+    @method get
+    @param {String} type Document type.
+    @param {String} id Document id.
+    @param {Object} [options] Options.
+      @param {String|String[]} [options.fields] Document field name or array of
+          field names to retrieve. By default, all fields are retrieved.
+    @param {Function} callback Callback function.
+      @param {Error|null} callback.err Error, or `null` on success.
+      @param {Object} callback.results Search results.
+      @param {Object} callback.res Full ElasticSearch response data.
+    @see Client.get
+    **/
+    mlt: function (type, id, options, callback) {
+        var query = [], params, url;
+
+        if (typeof options === 'function') {
+            callback = options;
+            options  = {};
+        }
+
+        params = util.merge(options);
+
+        if (params.fields) {
+            params.fields = Array.isArray(params.fields) ?
+                params.fields.join(',') : params.fields;
+        }
+
+        util.each(params, function (value, name) {
+            if (value === true || value === false) {
+                value = value ? '1' : '0';
+            }
+
+            query.push(encode(name) + '=' + encode(value));
+        });
+
+        url = '/' + encode(this.name) + '/' + encode(type) + '/' + encode(id) + '/_mlt';
+
+        if (query.length) {
+            url += '?' + query.join('&');
+        }
+
+        this.client._request(url, {method: 'GET'}, function (err, res) {
+            if (err) {
+                return callback(err);
+            }
+
+            callback(null, res.hits, res);
+        });
+    },
+
+    /**
     Gets the mapping definition for this index.
 
     [ElasticSearch docs](http://www.elasticsearch.org/guide/reference/api/admin-indices-get-mapping.html)

--- a/tests/offline-tests.js
+++ b/tests/offline-tests.js
@@ -351,6 +351,46 @@ vows.describe('Elastical').addBatch({
             }
         },
 
+        '`mlt()`': {
+            'without options': {
+                topic: function (client) {
+                    client._testHook = this.callback;
+                    client.mlt('twitter', 'tweet', 1);
+                },
+
+                'method should be GET': function (err, options) {
+                    assert.equal(options.method, 'GET');
+                },
+
+                'URL should have the correct path': function (err, options) {
+                    assert.equal(parseUrl(options.uri).pathname, '/twitter/tweet/1/_mlt');
+                }
+            },
+
+            'with options': {
+                topic: function (client) {
+                    client._testHook = this.callback;
+                    client.mlt('twitter', 'tweet', 1, {
+                      min_doc_freq: 1,
+                      min_term_freq: 1
+                    });
+                },
+
+                'URL should have the correct path': function (err, options) {
+                    assert.equal(parseUrl(options.uri).pathname, '/twitter/tweet/1/_mlt');
+                },
+
+                'URL query string should contain the options': function (err, options) {
+                    var query = parseUrl(options.uri, true).query;
+
+                    assert.deepEqual({
+                      min_doc_freq: '1',
+                      min_term_freq: '1'
+                    }, query);
+                }
+            }
+        },
+
         '`getIndex()` should get an Index instance': function (client) {
             var index = client.getIndex('foo');
 

--- a/tests/online-tests.js
+++ b/tests/online-tests.js
@@ -272,6 +272,63 @@ vows.describe('Elastical')
             }
         },
 
+        '`mlt()`': {
+            'when called with no options': {
+                topic: function (client) {
+                    client.mlt('elastical-test-mlt', 'post', '1', this.callback);
+                },
+
+                'should match no documents': function (err, hits, res) {
+                    assert.isNull(err);
+                    assert.isObject(hits);
+                    assert.isObject(res);
+
+                    assert.equal(hits.total, 0);
+                }
+            },
+            'when called with freq options': {
+                topic: function (client) {
+                    var options = {
+                      min_doc_freq: 1,
+                      min_term_freq: 1
+                    };
+
+                    client.mlt('elastical-test-mlt', 'post', '1', options,
+                        this.callback);
+                },
+
+                'should match 2 documents': function (err, hits, res) {
+                    assert.isNull(err);
+                    assert.isObject(hits);
+                    assert.isObject(res);
+
+                    assert.equal(hits.total, 2);
+                }
+            },
+            'when called with freq options and fields': {
+                topic: function (client) {
+                    var options = {
+                      min_doc_freq: 1,
+                      min_term_freq: 1,
+                      mlt_fields: [
+                        'a'
+                      ]
+                    };
+
+                    client.mlt('elastical-test-mlt', 'post', '1', options,
+                        this.callback);
+                },
+
+                'should match 1 document': function (err, hits, res) {
+                    assert.isNull(err);
+                    assert.isObject(hits);
+                    assert.isObject(res);
+
+                    assert.equal(hits.total, 1);
+                }
+            }
+        },
+
         '`multiGet()`': {
             'when called with no specific index': {
                 topic: function (client) {

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -92,6 +92,24 @@ curl -s -XPUT "$BASE/elastical-test-get/post/1" -d '{
 }'
 echo -e ""
 
+curl -s -XPUT "$BASE/elastical-test-mlt/post/1" -d '{
+  "a": "aaa bbb",
+  "b": "xxx"
+}'
+echo -e ""
+
+curl -s -XPUT "$BASE/elastical-test-mlt/post/2" -d '{
+  "a": "bbb ccc",
+  "b": "xxx"
+}'
+echo -e ""
+
+curl -s -XPUT "$BASE/elastical-test-mlt/post/3" -d '{
+  "a": "ccc ddd",
+  "b": "xxx"
+}'
+echo -e ""
+
 curl -s -XPUT "$BASE/elastical-test-delete/post/1" -d '{
   "title": "Delete me"
 }'


### PR DESCRIPTION
Hey, I've implemented mlt queries (aka. more_like_this) so now the client supports the shorthand provided by ElasticSearch. For more information:

http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-more-like-this.html
http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html

Feel free to discuss the commit and propose improvements or changes. I'd like to see it integrated in the code base.

Thanks.
