### PR TITLE
Removed options.curlDebug from count

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -212,7 +212,7 @@ Client.prototype = {
 
         hasOptions = !!Object.keys(options).length;
         url += '/_count';
-        options.curlDebug = true;
+        
         var myOptions = { method: hasOptions ? 'POST' : 'GET'};
         if(hasOptions){
           myOptions.json = options;


### PR DESCRIPTION
Not too sure why that line was there, but it was causing elasticsearch to throw.
